### PR TITLE
Fixed irrelevant bug

### DIFF
--- a/src/cursor.js
+++ b/src/cursor.js
@@ -76,7 +76,7 @@ function Cursor(root, path, solvedPath) {
       if (data && shouldFire) {
         self.emit('update');
       }
-      else {
+      else if (!data) {
         self.emit('irrelevant');
         self.relevant = false;
       }


### PR DESCRIPTION
Hi,

This seems to be a bug? It should only emit the irrelevant event if there is actually no data there? As the README also state: "Will fire if the cursor has become irrelevant and does **not watch over any data** anymore". I have had issues using the irrelevant event, but when I put this fix in there everything worked as expected.