### PR TITLE
Fixed reuse of released Baobab tree

### DIFF
--- a/src/baobab.js
+++ b/src/baobab.js
@@ -288,15 +288,15 @@ Baobab.prototype.undo = function() {
 };
 
 Baobab.prototype.release = function() {
-  this.kill();
-  delete this.data;
-  delete this._transaction;
-  delete this._history;
+  this.unbindAll();
+  this.data = {};
+  this._transaction = {};
+  this._history = [];
 
   // Releasing cursors
   for (var k in this._cursors)
     this._cursors[k].release();
-  delete this._cursors;
+  this._cursors = {};
 };
 
 /**

--- a/src/combination.js
+++ b/src/combination.js
@@ -113,7 +113,7 @@ makeOperator('and');
 Combination.prototype.release = function() {
 
   // Dropping own listeners
-  this.kill();
+  this.unbindAll();
 
   // Dropping cursors listeners
   this.cursors.forEach(function(cursor) {

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -325,7 +325,7 @@ Cursor.prototype.release = function() {
   if (this.hash)
     delete this.root._cursors[this.hash];
   this.root = null;
-  this.kill();
+  this.unbindAll();
 };
 
 /**

--- a/test/suites/baobab.js
+++ b/test/suites/baobab.js
@@ -109,6 +109,27 @@ describe('Baobab API', function() {
 
       assert(special.get('two'), baobab.get('two'));
     });
+
+    it('should be possible to release and reuse a Baobab tree', function () {
+      var tree = Baobab({
+        items: []
+      });
+      var counter = 0;
+      tree.on('update', function () {
+        counter++;
+      });
+      tree.release();
+      assert(tree.select('items').get() === undefined);
+
+      var array = [];
+      tree.set('items', array);
+      tree.on('update', function () {
+        assert(tree.select('items').get() === array);
+        assert(counter === 0);
+      });
+      tree.commit();
+    });
+
   });
 
   describe('Options', function() {


### PR DESCRIPTION
As talked about in issue https://github.com/Yomguithereal/baobab/pull/107.  If you want to create an isomorphic app with Baobab you have to release the tree every time it is being used on the server or you will get memory leaks. Currently when releasing the tree it is not possible to use it again. In this pull request the tree is released in the sense that all listeners and data are reset, but you are able to use it again by setting new data. 

Hope this makes sense! :-)