### PR TITLE
fix deep object matching in compare

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -116,9 +116,15 @@ function compare(object, spec) {
   var ok = true,
       k;
 
+  // If we reached here via a recursive call, object may be undefined because
+  // not all items in a collection will have the same deep nesting structure
+  if (!object) {
+    return false;
+  }
+
   for (k in spec) {
     if (type.Object(spec[k])) {
-      ok = ok && compare(object[k]);
+      ok = ok && compare(object[k], spec[k]);
     }
     else if (type.Array(spec[k])) {
       ok = ok && !!~spec[k].indexOf(object[k]);

--- a/test/state.js
+++ b/test/state.js
@@ -16,5 +16,9 @@ module.exports = {
   setLater: null,
   list: [[1, 2], [3, 4]],
   longList: [1, 2, 3, 4],
-  items: [{id: 'one'}, {id: 'two', user: {name: 'John', surname: 'Talbot'}}, {id: 'three'}]
+  items: [{id: 'one'}, {id: 'two', user: {name: 'John', surname: 'Talbot'}}, {id: 'three'}],
+  sameStructureItems: [
+    {id: 'one', user: {name: 'Jane', surname: 'Talbot'}},
+    {id: 'two', user: {name: 'John', surname: 'Talbot'}}
+  ]
 };

--- a/test/suites/helpers.js
+++ b/test/suites/helpers.js
@@ -30,6 +30,15 @@ describe('Helpers', function() {
       assert.strictEqual(helpers.getIn(state, ['one', 'subtwo', 'colors', 1]), 'yellow');
       assert.strictEqual(helpers.getIn(state, ['one', 'subtwo', 'colors', '1']), 'yellow');
       assert.strictEqual(helpers.getIn(state, ['inexistant', 'path']), undefined);
+      assert.strictEqual(helpers.getIn(state, ['items', {id: 'two'}]), state.items[1]);
+      assert.strictEqual(
+        helpers.getIn(state, ['items', {user: {surname: 'Talbot'}}]),
+        state.items[1]
+      );
+      assert.strictEqual(
+        helpers.getIn(state, ['sameStructureItems', {user: {name: 'John'}}]),
+        state.sameStructureItems[1]
+      );
     });
   });
 


### PR DESCRIPTION
Fixes two issues:

1) Using a nested object as a path argument to `getIn` was always returning the first item in the collection (providing that item had all the keys in the spec) because the value was not being tested.

e.g.

```js
var state = {
  items: [ { a: { b : 5 } } , { a: { b : 7 } } ]};

getIn('state', [ 'items', { a: { b:7 } } ]) === state.items[0]; // true
getIn('state', [ 'items', { a: { b:7 } } ]) === state.items[1]; // false
```

After this patch:

```js
getIn('state', [ 'items', { a: { b:7 } } ]) === state.items[0]; // false
getIn('state', [ 'items', { a: { b:7 } } ]) === state.items[1]; // true
```

2) If not all items in an array shared the same data structure, a null pointer was being thrown

```js
var state = {
  items: [ { id: 1 } , { id: 2 , a: { b : 7 } } ]};

getIn('state', [ 'items', { a: { b : 7 } } ]) === state.items[1]; // undefined does not understand b
```

After this patch:

```js
var state = {
  items: [ { id: 1 } , { id: 2 , a: { b : 7 } } ]};

getIn('state', [ 'items', { a: { b : 7 } } ]) === state.items[1]; // true
```

