### PR TITLE
Allow mixin cursor(s) to be specified as function

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,18 @@ var UserList = React.createClass({
     );
   }
 });
+
+// cursor(s) can be specified using a function
+var UserListItem = React.createClass({
+  mixins: [tree.mixin],
+  cursor: function() {
+    return ['users', this.props.index];
+  },
+  render: function() {
+    var name = this.cursor.get();
+    return <li>{name}</li>;
+  }
+});
 ```
 
 ##### Cursor level

--- a/src/mixins.js
+++ b/src/mixins.js
@@ -38,7 +38,11 @@ module.exports = {
 
           if (this.cursor) {
             if (!type.MixinCursor(this.cursor))
-              throw Error('baobab.mixin.cursor: invalid data (cursor, string or array).');
+              throw Error('baobab.mixin.cursor: invalid data (cursor, ' +
+                          'string, array or function).');
+
+            if (type.Function(this.cursor))
+              this.cursor = this.cursor();
 
             if (!type.Cursor(this.cursor))
               this.cursor = baobab.select(this.cursor);
@@ -49,8 +53,11 @@ module.exports = {
             this.__type = 'single';
           }
           else if (this.cursors) {
-            if (['object', 'array'].indexOf(type(this.cursors)) === -1)
-              throw Error('baobab.mixin.cursor: invalid data (object or array).');
+            if (!type.MixinCursors(this.cursors))
+              throw Error('baobab.mixin.cursor: invalid data (object, array or function).');
+
+            if (type.Function(this.cursors))
+              this.cursors = this.cursors();
 
             if (type.Array(this.cursors)) {
               this.cursors = this.cursors.map(function(path) {

--- a/src/type.js
+++ b/src/type.js
@@ -88,10 +88,16 @@ type.Path = function (value) {
 
 };
 
-// string|number|array|cursor
+// string|number|array|cursor|function
 type.MixinCursor = function (value) {
-  var allowedValues = ['string', 'number', 'array'];
+  var allowedValues = ['string', 'number', 'array', 'function'];
   return allowedValues.indexOf(type(value)) >= 0 || type.Cursor(value);
+};
+
+// array|object|function
+type.MixinCursors = function (value) {
+  var allowedValues = ['array', 'object', 'function'];
+  return allowedValues.indexOf(type(value)) >= 0;
 };
 
 // Already know this is an array

--- a/test/suites/mixins.js
+++ b/test/suites/mixins.js
@@ -146,6 +146,54 @@ describe('React Mixins', function() {
       });
     });
 
+    it('should be possible to pass a function returning a path.', function(done) {
+      var baobab = new Baobab({hello:'world'});
+
+      var Component = React.createClass({
+        mixins: [baobab.mixin],
+        cursor: function() {
+          return ['hello'];
+        },
+        render: function() {
+          return React.createElement('div', {id: 'treepath'}, this.cursor.get());
+        }
+      });
+
+      React.render(React.createElement(Component, null), document.body, function() {
+        assert.strictEqual(document.querySelector('#treepath').textContent, 'world');
+
+        baobab.set('hello', 'john');
+        setTimeout(function() {
+          assert.strictEqual(document.querySelector('#treepath').textContent, 'john');
+          done();
+        }, 0);
+      });
+    });
+
+    it('should be possible to pass a function returning a single cursor.', function(done) {
+      var baobab = new Baobab({hello:'world'});
+
+      var Component = React.createClass({
+        mixins: [baobab.mixin],
+        cursor: function() {
+          return baobab.select('hello');
+        },
+        render: function() {
+          return React.createElement('div', {id: 'treepath'}, this.cursor.get());
+        }
+      });
+
+      React.render(React.createElement(Component, null), document.body, function() {
+        assert.strictEqual(document.querySelector('#treepath').textContent, 'world');
+
+        baobab.set('hello', 'john');
+        setTimeout(function() {
+          assert.strictEqual(document.querySelector('#treepath').textContent, 'john');
+          done();
+        }, 0);
+      });
+    });
+
     it('should be possible to pass an array of paths.', function(done) {
       var baobab = new Baobab({name:'John', surname: 'Talbot'}),
           i = 0;
@@ -231,6 +279,57 @@ describe('React Mixins', function() {
         cursors: {
           name: ['name'],
           surname: baobab.select('surname')
+        },
+        render: function() {
+          return React.createElement('div', {id: 'treepathoc'}, this.cursors.name.get() + ' ' + this.cursors.surname.get());
+        }
+      });
+
+      React.render(React.createElement(Component, null), document.body, function() {
+        assert.strictEqual(document.querySelector('#treepathoc').textContent, 'John Talbot');
+
+        baobab.set('name', 'Jack');
+        setTimeout(function() {
+          assert.strictEqual(document.querySelector('#treepathoc').textContent, 'Jack Talbot');
+          done();
+        }, 0);
+      });
+    });
+
+    it('should be possible to pass a function returning an array of cursors.', function(done) {
+      var baobab = new Baobab({name:'John', surname: 'Talbot'});
+
+      var Component = React.createClass({
+        mixins: [baobab.mixin],
+        cursors: function() {
+          return [['name'], baobab.select('surname')];
+        },
+        render: function() {
+          return React.createElement('div', {id: 'treepathcursors'}, this.cursors[0].get() + ' ' + this.cursors[1].get());
+        }
+      });
+
+      React.render(React.createElement(Component, null), document.body, function() {
+        assert.strictEqual(document.querySelector('#treepathcursors').textContent, 'John Talbot');
+
+        baobab.set('name', 'Jack');
+        setTimeout(function() {
+          assert.strictEqual(document.querySelector('#treepathcursors').textContent, 'Jack Talbot');
+          done();
+        }, 0);
+      });
+    });
+
+    it('should be possible to pass function returning an object of cursors.', function(done) {
+      var baobab = new Baobab({name:'John', surname: 'Talbot'});
+
+      var Component = React.createClass({
+        mixins: [baobab.mixin],
+        cursors: function() {
+          return {
+            name: ['name'],
+            surname: baobab.select('surname')
+          };
         },
         render: function() {
           return React.createElement('div', {id: 'treepathoc'}, this.cursors.name.get() + ' ' + this.cursors.surname.get());

--- a/test/suites/mixins.js
+++ b/test/suites/mixins.js
@@ -152,14 +152,14 @@ describe('React Mixins', function() {
       var Component = React.createClass({
         mixins: [baobab.mixin],
         cursor: function() {
-          return ['hello'];
+          return [this.props.pathKey];
         },
         render: function() {
           return React.createElement('div', {id: 'treepath'}, this.cursor.get());
         }
       });
 
-      React.render(React.createElement(Component, null), document.body, function() {
+      React.render(React.createElement(Component, {pathKey: 'hello'}), document.body, function() {
         assert.strictEqual(document.querySelector('#treepath').textContent, 'world');
 
         baobab.set('hello', 'john');
@@ -176,14 +176,14 @@ describe('React Mixins', function() {
       var Component = React.createClass({
         mixins: [baobab.mixin],
         cursor: function() {
-          return baobab.select('hello');
+          return baobab.select(this.props.pathKey);
         },
         render: function() {
           return React.createElement('div', {id: 'treepath'}, this.cursor.get());
         }
       });
 
-      React.render(React.createElement(Component, null), document.body, function() {
+      React.render(React.createElement(Component, {pathKey: 'hello'}), document.body, function() {
         assert.strictEqual(document.querySelector('#treepath').textContent, 'world');
 
         baobab.set('hello', 'john');
@@ -302,14 +302,14 @@ describe('React Mixins', function() {
       var Component = React.createClass({
         mixins: [baobab.mixin],
         cursors: function() {
-          return [['name'], baobab.select('surname')];
+          return [[this.props.pathKey1], baobab.select(this.props.pathKey2)];
         },
         render: function() {
           return React.createElement('div', {id: 'treepathcursors'}, this.cursors[0].get() + ' ' + this.cursors[1].get());
         }
       });
 
-      React.render(React.createElement(Component, null), document.body, function() {
+      React.render(React.createElement(Component, {pathKey1: 'name', pathKey2: 'surname'}), document.body, function() {
         assert.strictEqual(document.querySelector('#treepathcursors').textContent, 'John Talbot');
 
         baobab.set('name', 'Jack');
@@ -327,8 +327,8 @@ describe('React Mixins', function() {
         mixins: [baobab.mixin],
         cursors: function() {
           return {
-            name: ['name'],
-            surname: baobab.select('surname')
+            name: [this.props.pathKey1],
+            surname: baobab.select(this.props.pathKey2)
           };
         },
         render: function() {
@@ -336,7 +336,7 @@ describe('React Mixins', function() {
         }
       });
 
-      React.render(React.createElement(Component, null), document.body, function() {
+      React.render(React.createElement(Component, {pathKey1: 'name', pathKey2: 'surname'}), document.body, function() {
         assert.strictEqual(document.querySelector('#treepathoc').textContent, 'John Talbot');
 
         baobab.set('name', 'Jack');


### PR DESCRIPTION
These changes allow the React mixin's `cursor` and `cursors` parameters to be specified as a function which returns one of the already supported forms (path, cursor object, etc.). This makes it easy to dynamically calculate the cursor path(s) from e.g. the props of the component. Example:

```javascript
var tree = new Baobab({
  notesById: {
    'a020d1ee': "... a note ...",
    '570f4877': "... another note ..."
  }
});

var NoteView = React.createClass({
  mixins: [tree.mixin],
  
  cursor: function() {
    return ['notesById', this.props.noteId];
  },

  render: function() {
    var text = this.cursor.get();
    return <article>{text}</article>;
  }
});
```