### PR TITLE
Use 'the library' instead of the gendered pronoun 'he' in the Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ var colorCursor = paletteCursor.select('colors');
 
 #### Updates
 
-A *baobab* tree can obviously be updated. However, one has to understand that they won't do it, at least by default, synchronously.
+A *baobab* tree can obviously be updated. However, one has to understand that the library won't do so, at least by default, synchronously.
 
 Rather, the tree will stack and merge every update order you give it and will only commit them later on (note that you remain free to force a synchronous update of the tree through `tree.commit` or by tweaking the tree's [options](#options)).
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ var colorCursor = paletteCursor.select('colors');
 
 #### Updates
 
-A *baobab* tree can obviously be updated. However, one has to understand that he won't do it, at least by default, synchronously.
+A *baobab* tree can obviously be updated. However, one has to understand that they won't do it, at least by default, synchronously.
 
 Rather, the tree will stack and merge every update order you give it and will only commit them later on (note that you remain free to force a synchronous update of the tree through `tree.commit` or by tweaking the tree's [options](#options)).
 


### PR DESCRIPTION
This is, of course, a matter of some linguistic preference, but seeing as the word `one` is used earlier in the sentence, it's already set up to be gender-neutral :)

Some food for thought:
* http://en.wikipedia.org/wiki/Gender-specific_and_gender-neutral_pronouns#Singular_they
* http://www.oxforddictionaries.com/words/he-or-she-versus-they

Cheers!