### PR TITLE
Add benchmark suite.

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1,0 +1,50 @@
+var Benchmark = require('benchmark');
+var Baobab = require('./');
+
+var suite = new Benchmark.Suite;
+
+var tree = new Baobab({
+  a: {
+    b: {
+      c: {
+        d: {
+          e: {
+            f: {
+              g: []
+            }
+          }
+        }
+      }
+    }
+  }
+});
+
+var cursor = tree.select(['a', 'b', 'c']);
+
+suite
+  .add('Baobab#set', function () {
+    tree.set(['a', 'b', 'c', 'foo'], 'bar');
+  })
+  .add('Baobab#unset', function () {
+    tree.unset(['a', 'b', 'c', 'foo']);
+  })
+  .add('Baobab.Cursor#set', function () {
+    cursor.set({ d: { e: { f: { g: [] } } } });
+    cursor.set(['d', 'e', 'f', 'foo'], 'bar');
+  })
+  .add('Baobab.Cursor#unset', function () {
+    cursor.unset(['d', 'e', 'f', 'foo']);
+  })
+  .add('Baobab.Cursor#push', function () {
+    cursor.push(['d', 'e', 'f', 'g'], 'baobab');
+  })
+  .add('Baobab.Cursor#unshift', function () {
+    cursor.unshift(['d', 'e', 'f', 'g'], 'baobab');
+  })
+  .add('Baobab.Cursor#splice', function () {
+    cursor.splice(['d', 'e', 'f', 'g'], [1, 1, 'baobab']);
+  })
+  .on('cycle', function (event) {
+    console.log(String(event.target));
+  })
+  .run();

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "devDependencies": {
     "async": "~0.9.0",
+    "benchmark": "^1.0.0",
     "browserify": "^9.0.3",
     "gulp": "^3.8.10",
     "gulp-header": "^1.2.2",


### PR DESCRIPTION
Adding a simple benchmark suite (for #191) to track performance regressions.

```
alex@localhost> node benchmark.js
Baobab#set x 50,628 ops/sec ±0.80% (94 runs sampled)
Baobab#unset x 52,336 ops/sec ±1.01% (95 runs sampled)
Baobab.Cursor#set x 22,998 ops/sec ±0.76% (97 runs sampled)
Baobab.Cursor#unset x 34,665 ops/sec ±1.78% (94 runs sampled)
Baobab.Cursor#push x 4,308 ops/sec ±24.79% (17 runs sampled)
Baobab.Cursor#unshift x 9,457 ops/sec ±4.31% (78 runs sampled)
Baobab.Cursor#splice x 5,777 ops/sec ±3.07% (80 runs sampled)
```