### PR TITLE
Fix Traversal docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,9 @@ listCursor.down().right().get();
 listCursor.select(1).down().right().get();
 >>> 4
 
+listCursor.select(1).down().right().left().get();
+>>> 3
+
 twoCursor.leftmost().get();
 >>> 'one'
 

--- a/README.md
+++ b/README.md
@@ -502,8 +502,8 @@ var listCursor = tree.select('list'),
 listCursor.down().right().get();
 >>> [3, 4]
 
-listCursor.select(1).down().left().get();
->>> 3
+listCursor.select(1).down().right().get();
+>>> 4
 
 twoCursor.leftmost().get();
 >>> 'one'


### PR DESCRIPTION
In README:

```js
listCursor.select(1).down().left().get();
```

Throws an error:

```js
listCursor.select(1).down().left().get();
                                  ^
TypeError: Cannot read property 'get' of null
````

I've it changed to:

```js
listCursor.select(1).down().right().get();
```

And now it returns:

```js
4
```