### PR TITLE
pass original unsolved path to `get` event

### DIFF
--- a/src/cursor.js
+++ b/src/cursor.js
@@ -261,7 +261,7 @@ Cursor.prototype.get = function(path) {
 
   // Emitting an event
   if (!skipEvent)
-    this.tree.emit('get', {path: fullPath, data: data});
+    this.tree.emit('get', {path: fullPath, unsolvedPath: this.path, data: data});
 
   return data;
 };


### PR DESCRIPTION
hi.

it would be nice to get an original "unsolved" path inside `get`-event callback – in my case I need to know what path is not found, `-1` is not enough for a complex cursor path.