### PR TITLE
Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ var colorCursor = paletteCursor.select('colors');
 
 A *baobab* tree can obviously be updated. However, one has to understand that the library won't do so, at least by default, synchronously.
 
-Rather, the tree will stack and merge every update order you give it and will only commit them later on (note that you remain free to force a synchronous update of the tree through `tree.commit` or by tweaking the tree's [options](#options)).
+Rather, the tree will stack and merge every update order you give it and will only commit them later on (note that you remain free to force a synchronous update of the tree through `tree.commit()` or by tweaking the tree's [options](#options)).
 
 This enables the tree to perform efficient mutations and to be able to notify any relevant cursors that the data they are watching over has changed.
 
@@ -672,7 +672,7 @@ facet.on('update', function() {
 *Example*
 
 ```js
-// Asynchronous tree so that examples are simpler
+// Synchronous tree so that examples are simpler
 var baobab = new Baobab({colors: ['blue']}, {asynchronous: false}),
     cursor = baobab.select('colors');
 


### PR DESCRIPTION
Fix a typo, add `()` to a call.