### PR TITLE
Publish gulpfile to NPM

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,7 +5,6 @@ node_modules
 .travis.yml
 test/
 build/
-gulpfile.js
 benchmark.js
 *.log
 .eslintrc


### PR DESCRIPTION
To allow `npm run build` in `node_modules/baobab`.