### PR TITLE
Make eager monkeys lazy

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -255,6 +255,10 @@ function freezer(deep, o) {
         k;
 
     for (k in o) {
+      var descriptor = Object.getOwnPropertyDescriptor(o, k);
+      if(descriptor && descriptor.get && descriptor.get.name == 'lazyGetter')
+        continue;
+
       p = o[k];
 
       if (!p ||

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -255,8 +255,8 @@ function freezer(deep, o) {
         k;
 
     for (k in o) {
-      var descriptor = Object.getOwnPropertyDescriptor(o, k);
-      if(descriptor && descriptor.get && descriptor.get.name == 'lazyGetter')
+      const descriptor = Object.getOwnPropertyDescriptor(o, k);
+      if(type.isLazyGetter(descriptor))
         continue;
 
       p = o[k];

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -255,8 +255,7 @@ function freezer(deep, o) {
         k;
 
     for (k in o) {
-      const descriptor = Object.getOwnPropertyDescriptor(o, k);
-      if(type.isLazyGetter(descriptor))
+      if(type.lazyGetter(o, k))
         continue;
 
       p = o[k];

--- a/src/monkey.js
+++ b/src/monkey.js
@@ -182,7 +182,7 @@ export class Monkey {
         return cache;
       };
     })(this.tree, this.definition, deps);
-
+    lazyGetter.isLazyGetter = true;
     this.tree._data = update(
       this.tree._data,
       this.path,

--- a/src/type.js
+++ b/src/type.js
@@ -175,6 +175,16 @@ type.monkeyPath = function(data, path) {
 };
 
 /**
+ * Check if the data is a lazy getter for a monkey.
+ *
+ * @param  {mixed} data - The data to test.
+ * @return {boolean}
+ */
+type.isLazyGetter = function(propertyDescriptor) {
+      return propertyDescriptor && propertyDescriptor.get && propertyDescriptor.get.isLazyGetter === true;
+};
+
+/**
  * Returns the type of the given monkey definition or `null` if invalid.
  *
  * @param  {mixed} definition - The definition to check.

--- a/src/type.js
+++ b/src/type.js
@@ -180,8 +180,10 @@ type.monkeyPath = function(data, path) {
  * @param  {mixed} data - The data to test.
  * @return {boolean}
  */
-type.isLazyGetter = function(propertyDescriptor) {
-      return propertyDescriptor && propertyDescriptor.get && propertyDescriptor.get.isLazyGetter === true;
+type.lazyGetter = function(o, propertyKey) {
+  var descriptor = Object.getOwnPropertyDescriptor(o, propertyKey);
+
+  return descriptor && descriptor.get && descriptor.get.isLazyGetter === true;
 };
 
 /**

--- a/src/update.js
+++ b/src/update.js
@@ -5,6 +5,7 @@
  * The tree's update scheme.
  */
 import type from './type';
+import {MonkeyDefinition} from './monkey';
 import {
   freeze,
   deepFreeze,
@@ -69,8 +70,14 @@ export default function update(data, path, operation, opts={}) {
         // Purity check
         if (opts.pure && p[s] === value)
           return {node: p[s]};
-
-        p[s] = opts.persistent ? shallowClone(value) : value;
+        
+        if(opts.persistent) {
+          p[s] = shallowClone(value);
+        } else if(value instanceof MonkeyDefinition) {
+          Object.defineProperty(p, s, {value: value, enumerable: true, configurable: true});
+        } else {
+          p[s] = value;
+        }
       }
 
       /**

--- a/src/update.js
+++ b/src/update.js
@@ -84,7 +84,7 @@ export default function update(data, path, operation, opts={}) {
        * Monkey
        */
       else if (operationType === 'monkey') {
-        Object.defineProperty(p, s, {get: function lazyGetter() { return value(); }, enumerable: true, configurable: true});
+        Object.defineProperty(p, s, {get: value, enumerable: true, configurable: true});
       }
 
       /**
@@ -239,7 +239,7 @@ export default function update(data, path, operation, opts={}) {
   // Returning new data object
 
   var descriptor = Object.getOwnPropertyDescriptor(p, s);
-  if(descriptor && descriptor.get && descriptor.get.name == 'lazyGetter')
+  if(type.isLazyGetter(descriptor))
     return { data: dummy.root };
 
   return {data: dummy.root, node: p[s]};

--- a/src/update.js
+++ b/src/update.js
@@ -238,8 +238,7 @@ export default function update(data, path, operation, opts={}) {
 
   // Returning new data object
 
-  var descriptor = Object.getOwnPropertyDescriptor(p, s);
-  if(type.isLazyGetter(descriptor))
+  if(type.lazyGetter(p, s))
     return { data: dummy.root };
 
   return {data: dummy.root, node: p[s]};

--- a/src/update.js
+++ b/src/update.js
@@ -84,7 +84,7 @@ export default function update(data, path, operation, opts={}) {
        * Monkey
        */
       else if (operationType === 'monkey') {
-        Object.defineProperty(p, s, {get: value, enumerable: true});
+        Object.defineProperty(p, s, {get: function lazyGetter() { return value(); }, enumerable: true, configurable: true});
       }
 
       /**
@@ -237,5 +237,10 @@ export default function update(data, path, operation, opts={}) {
   }
 
   // Returning new data object
+
+  var descriptor = Object.getOwnPropertyDescriptor(p, s);
+  if(descriptor && descriptor.get && descriptor.get.name == 'lazyGetter')
+    return { data: dummy.root };
+
   return {data: dummy.root, node: p[s]};
 }

--- a/test/suites/monkey.js
+++ b/test/suites/monkey.js
@@ -510,10 +510,10 @@ describe('Monkeys', function() {
       assert.strictEqual('yellow', yellow);
 
       tree.set(['data', 'selected'], monkey(['data', 'colors'], function(c) {
-                if(shouldHaveBeenCalled)
-                  return c[1];
-                else
-                  throw new Error('should not be called');
+        if(shouldHaveBeenCalled)
+          return c[1];
+        else
+          throw new Error('should not be called');
       }));
       shouldHaveBeenCalled = true;
       var blue = tree.get('data','selected');
@@ -560,10 +560,10 @@ describe('Monkeys', function() {
       assert.strictEqual('yellow', yellow);
 
       tree.set(['data', 'selected'], monkey(['data', 'colors'], function(c) {
-                if(shouldHaveBeenCalled)
-                  return c[1];
-                else
-                  throw new Error('should not be called');
+        if(shouldHaveBeenCalled)
+          return c[1];
+        else
+          throw new Error('should not be called');
       }));
       shouldHaveBeenCalled = true;
       var blue = tree.get('data','selected');

--- a/test/suites/monkey.js
+++ b/test/suites/monkey.js
@@ -403,7 +403,7 @@ describe('Monkeys', function() {
       assert.strictEqual(tree.get('data', 'selected'), 'purple');
     });
 
-    it('with persistent tree', function() {
+    it('with non-persistent tree', function() {
       const tree = new Baobab(
         {
           data: {
@@ -420,6 +420,43 @@ describe('Monkeys', function() {
       tree.set(['data', 'colors', 1], 'purple');
       assert.strictEqual(tree.get('data', 'selected'), 'purple');
     });
+
+    it('with impure tree', function() {
+      const tree = new Baobab(
+        {
+          data: {
+            colors: ['yellow', 'blue'],
+            selected: monkey(['data', 'colors'], c => c[0])
+          }
+        },
+        {asynchronous: false, pure: false}
+      );
+    
+      assert.strictEqual(tree.get('data', 'selected'), 'yellow');  
+      tree.set(['data', 'selected'], monkey(['data', 'colors'], c => c[1]));  
+      assert.strictEqual(tree.get('data', 'selected'), 'blue');
+      tree.set(['data', 'colors', 1], 'purple');
+      assert.strictEqual(tree.get('data', 'selected'), 'purple');
+    });
+
+	it('with mutable, non-persistent, impure tree', function() {
+      const tree = new Baobab(
+        {
+          data: {
+            colors: ['yellow', 'blue'],
+            selected: monkey(['data', 'colors'], c => c[0])
+          }
+        },
+        {asynchronous: false, immutable: false, persistent: false, pure: false}
+      );
+    
+      assert.strictEqual(tree.get('data', 'selected'), 'yellow');  
+      tree.set(['data', 'selected'], monkey(['data', 'colors'], c => c[1]));  
+      assert.strictEqual(tree.get('data', 'selected'), 'blue');
+      tree.set(['data', 'colors', 1], 'purple');
+      assert.strictEqual(tree.get('data', 'selected'), 'purple');
+    });
+
   });
 
   it('should be possible to drop monkeys somehow.', function() {

--- a/test/suites/monkey.js
+++ b/test/suites/monkey.js
@@ -366,26 +366,60 @@ describe('Monkeys', function() {
     assert.deepEqual(tree.get('data', 'computed', 'leader'), ['yellow']);
   });
 
-  it('should be possible to replace monkeys at runtime.', function() {
-    const tree = new Baobab(
-      {
-        data: {
-          colors: ['yellow', 'blue'],
-          selected: monkey(['data', 'colors'], c => c[0])
-        }
-      },
-      {asynchronous: false}
-    );
+  describe('should be possible to replace monkeys at runtime.', function() {
+    it('with default tree', function() {
+      const tree = new Baobab(
+        {
+          data: {
+            colors: ['yellow', 'blue'],
+            selected: monkey(['data', 'colors'], c => c[0])
+          }
+        },
+        {asynchronous: false}
+      );
+  
+      assert.strictEqual(tree.get('data', 'selected'), 'yellow');  
+      tree.set(['data', 'selected'], monkey(['data', 'colors'], c => c[1]));  
+      assert.strictEqual(tree.get('data', 'selected'), 'blue');
+      tree.set(['data', 'colors', 1], 'purple');
+      assert.strictEqual(tree.get('data', 'selected'), 'purple');
+    });
 
-    assert.strictEqual(tree.get('data', 'selected'), 'yellow');
+    it('with mutable tree', function() {
+      const tree = new Baobab(
+        {
+          data: {
+            colors: ['yellow', 'blue'],
+            selected: monkey(['data', 'colors'], c => c[0])
+          }
+        },
+        {asynchronous: false, immutable: false}
+      );
+  
+      assert.strictEqual(tree.get('data', 'selected'), 'yellow');  
+      tree.set(['data', 'selected'], monkey(['data', 'colors'], c => c[1]));  
+      assert.strictEqual(tree.get('data', 'selected'), 'blue');
+      tree.set(['data', 'colors', 1], 'purple');
+      assert.strictEqual(tree.get('data', 'selected'), 'purple');
+    });
 
-    tree.set(['data', 'selected'], monkey(['data', 'colors'], c => c[1]));
-
-    assert.strictEqual(tree.get('data', 'selected'), 'blue');
-
-    tree.set(['data', 'colors', 1], 'purple');
-
-    assert.strictEqual(tree.get('data', 'selected'), 'purple');
+    it('with persistent tree', function() {
+      const tree = new Baobab(
+        {
+          data: {
+            colors: ['yellow', 'blue'],
+            selected: monkey(['data', 'colors'], c => c[0])
+          }
+        },
+        {asynchronous: false, persistent: false}
+      );
+  
+      assert.strictEqual(tree.get('data', 'selected'), 'yellow');  
+      tree.set(['data', 'selected'], monkey(['data', 'colors'], c => c[1]));  
+      assert.strictEqual(tree.get('data', 'selected'), 'blue');
+      tree.set(['data', 'colors', 1], 'purple');
+      assert.strictEqual(tree.get('data', 'selected'), 'purple');
+    });
   });
 
   it('should be possible to drop monkeys somehow.', function() {

--- a/test/suites/monkey.js
+++ b/test/suites/monkey.js
@@ -492,4 +492,104 @@ describe('Monkeys', function() {
 
     assert.strictEqual(altTree.get('user', 'fullname'), 'Hello Jack');
   });
+  
+  describe('with immutable and persistent tree', function () {
+    it('should be lazy if added at runtime', function() {
+      var shouldHaveBeenCalled = false;
+      const tree = new Baobab(
+        {
+          data: {
+            colors: ['yellow', 'blue'],
+            selected: monkey(['data', 'colors'], c => c[0])
+          }
+        },
+        {asynchronous: false, immutable: true, persistent: true}
+      );
+
+      var yellow = tree.get('data','selected');
+      assert.strictEqual('yellow', yellow);
+
+      tree.set(['data', 'selected'], monkey(['data', 'colors'], function(c) {
+                if(shouldHaveBeenCalled)
+                  return c[1];
+                else
+                  throw new Error('should not be called');
+      }));
+      shouldHaveBeenCalled = true;
+      var blue = tree.get('data','selected');
+      assert.strictEqual('blue', blue);
+    });
+
+    it('should be lazy', function() {
+      var shouldHaveBeenCalled = false;
+      const tree = new Baobab(
+          {
+            data: {
+              colors: ['yellow', 'blue'],
+              selected: monkey(['data', 'colors'], function(c) {
+                if(shouldHaveBeenCalled)
+                  return c[0];
+                else
+                  throw new Error('should not be called');
+              })
+            }
+          },
+          {asynchronous: false, immutable: true, persistent: true}
+        );
+
+        shouldHaveBeenCalled = true;
+        var yellow = tree.get('data', 'selected');
+        assert.strictEqual('yellow', yellow);
+    });
+  });
+
+  describe('without immutability or persistance', function() {
+    it('should be lazy if added at runtime', function() {
+      var shouldHaveBeenCalled = false;
+      const tree = new Baobab(
+        {
+          data: {
+            colors: ['yellow', 'blue'],
+            selected: monkey(['data', 'colors'], c => c[0])
+          }
+        },
+        {asynchronous: false, immutable: false, persistent: false}
+      );
+
+      var yellow = tree.get('data','selected');
+      assert.strictEqual('yellow', yellow);
+
+      tree.set(['data', 'selected'], monkey(['data', 'colors'], function(c) {
+                if(shouldHaveBeenCalled)
+                  return c[1];
+                else
+                  throw new Error('should not be called');
+      }));
+      shouldHaveBeenCalled = true;
+      var blue = tree.get('data','selected');
+      assert.strictEqual('blue', blue);
+    });
+
+    it('should be lazy', function() {
+      var shouldHaveBeenCalled = false;
+      const tree = new Baobab(
+          {
+            data: {
+              colors: ['yellow', 'blue'],
+              selected: monkey(['data', 'colors'], function(c) {
+                if(shouldHaveBeenCalled)
+                  return c[0];
+                else
+                  throw new Error('should not be called');
+              })
+            }
+          },
+          {asynchronous: false, immutable: false, persistent: false}
+        );
+
+        shouldHaveBeenCalled = true;
+        var yellow = tree.get('data', 'selected');
+        assert.strictEqual('yellow', yellow);
+    });
+  });
 });


### PR DESCRIPTION
First I'd like to thank you for an excellent project! :+1: 

After exploring the code, debugging, and looking at stacktraces it if found three places where monkeys were evaluated to soon.
 - When freezing the tree because of immutability
 - When replacing a monkey at runtime if the tree wasn't persistent
 - And when setting the monkey with the monkey operation

The reason for the premature evaluation was that using Object.defineProperty with a getter gets evaluated immediately when the property is accessed. So the solution was to simply to avoid accessing any monkey properties when manipulating the tree.

Fixes #362 