### PR TITLE
Add support for ES6 collections

### DIFF
--- a/src/type.js
+++ b/src/type.js
@@ -54,7 +54,9 @@ type.object = function(target) {
          typeof target === 'object' &&
          !Array.isArray(target) &&
          !(target instanceof Date) &&
-         !(target instanceof RegExp);
+         !(target instanceof RegExp) && 
+         (typeof Map === 'function' && !(target instanceof Map)) &&
+         (typeof Set === 'function' && !(target instanceof Set));
 };
 
 /**

--- a/src/type.js
+++ b/src/type.js
@@ -55,8 +55,8 @@ type.object = function(target) {
          !Array.isArray(target) &&
          !(target instanceof Date) &&
          !(target instanceof RegExp) && 
-         (typeof Map === 'function' && !(target instanceof Map)) &&
-         (typeof Set === 'function' && !(target instanceof Set));
+         !(typeof Map === 'function' && target instanceof Map) &&
+         !(typeof Set === 'function' && target instanceof Set);
 };
 
 /**


### PR DESCRIPTION
Example:
```js
let heroes = new Map();

heroes.set('batman', {
  name: 'Batman',
  car: 'batmobile',
  buddies: ['robin']
});

tree.select().set(['npc', 'heroes'], heroes);
```

Error:
```js
const result = tree.select().get('npc');
console.log(result); // Object{ heroes: Object{} }
```

Anyway, ES6 collections might not be the right choice as values in Baobab.

1. `Map` and `Set` can not be freezed (See: [Stack Overflow: Is it possible to “freeze” a Set (or Map)?](http://stackoverflow.com/questions/31509175/in-javascript-is-it-possible-to-freeze-a-set-or-map))

2. It is not possible to compare collections with native methods, as it is difficult to implement properly and efficiently. It was considered before to hand callbacks to collections that specify equality (like `Map.equals`) but the proposal was rejected in favor of ES7 [value objects](http://www.slideshare.net/BrendanEich/value-objects) for keys instead of objects.

In Java it is possible to specify equality via ([`equals()`](http://docs.oracle.com/javase/7/docs/api/java/util/Map.html#equals(java.lang.Object))). 

> `boolean equals(Object o)`
>
> Compares the specified object with this map for equality. Returns true if the given object is also a map and the two maps represent the same mappings.

However, this approach is **problematic** for mutable objects: In general, if an `object` changes, its “location” inside, a collection has to change, as well. But that’s not what happens in Java. Another issue is, that all native types (string, number, boolean, undefined, null, object) can be keys.

@Yomguithereal