### PR TITLE
[W.I.P.] Fixes cursor's recording state when restarting a history

### DIFF
--- a/src/cursor.js
+++ b/src/cursor.js
@@ -556,6 +556,8 @@ export default class Cursor extends Emitter {
         value: maxRecords
       });
 
+    this.state.recording = true;
+
     if (this.archive)
       return this;
 
@@ -563,7 +565,6 @@ export default class Cursor extends Emitter {
     this._lazyBind();
 
     this.archive = new Archive(maxRecords);
-    this.state.recording = true;
     return this;
   }
 


### PR DESCRIPTION
Sets the correct recording state when starting a history at a cursor after having stopped it before.

As of right now starting a history a second time after having stopped it before does not add future changes to the archive due to not setting `state.recording = true`  when an `Archive` is present. :hushed:

Marking as w.i.p. as I think a test might be desirable? Anything else? :octocat: