### PR TITLE
Only use es2015 if supported

### DIFF
--- a/src/cursor.js
+++ b/src/cursor.js
@@ -386,40 +386,6 @@ export default class Cursor extends Emitter {
   }
 
   /**
-   * Method used to allow iterating over cursors containing list-type data.
-   *
-   * e.g. for(let i of cursor) { ... }
-   *
-   * @returns {object} -  Each item sequentially.
-   */
-  [Symbol.iterator]() {
-    let array = this._get().data;
-
-    if (!type.array(array))
-      throw Error('baobab.Cursor.@@iterate: cannot iterate a non-list type.');
-
-    let i = 0;
-
-    const cursor = this,
-          length = array.length;
-
-    return {
-      next: function() {
-        if (i < length) {
-          return {
-            value: cursor.select(i++)
-          };
-        }
-        else {
-          return {
-            done: true
-          };
-        }
-      }
-    };
-  }
-
-  /**
    * Getter Methods
    * ---------------
    */
@@ -714,6 +680,42 @@ export default class Cursor extends Emitter {
    */
   toString() {
     return this._identity;
+  }
+}
+
+/**
+ * Method used to allow iterating over cursors containing list-type data.
+ *
+ * e.g. for(let i of cursor) { ... }
+ *
+ * @returns {object} -  Each item sequentially.
+ */
+if(typeof Symbol === 'function' && typeof Symbol.iterator !== 'undefined') {
+  Cursor.prototype[Symbol.iterator] = function() {
+    let array = this._get().data;
+
+    if (!type.array(array))
+      throw Error('baobab.Cursor.@@iterate: cannot iterate a non-list type.');
+
+    let i = 0;
+
+    const cursor = this,
+      length = array.length;
+
+    return {
+      next: function (){
+        if (i < length) {
+          return {
+            value: cursor.select(i++)
+          };
+        }
+        else {
+          return {
+            done: true
+          };
+        }
+      }
+    };
   }
 }
 


### PR DESCRIPTION
Move iteration support to helpers module.
    Only add it when it is supported.
    This would allow to avoid having to include babel runtime
    See #386
