### PR TITLE
Test-case for wrong dynamic path behaviour

### DIFF
--- a/test/suites/monkey.js
+++ b/test/suites/monkey.js
@@ -155,6 +155,22 @@ describe('Monkeys', function() {
     assert.strictEqual(tree.get('greeting'), 'Hello Jack');
   });
 
+  it('monkeys should be able to work with dynamic paths on empty collection', function() {
+    const tree = new Baobab({
+      elements: [],
+      computed: monkey(['elements'], elements => elements)
+    });
+
+    tree.set(['element'], monkey(
+      ['computed', {option: true}],
+      title => title
+    ));
+
+    const element = tree.get(['element']);
+
+    assert.equal(undefined, element);
+  });
+
   it('cursors with a monkey in the path should work correctly.', function(done) {
     const tree = new Baobab(getExampleState()),
           cursor = tree.select('data', 'fromJohn');


### PR DESCRIPTION
Found some strange case for dynamic path monkey selection from empty monkey collection. Case work only if monkey field with dynamic selection path will be set to already created Baobab tree.
