### PR TITLE
update example missing assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,7 @@ Will fire if data watched over by the cursor has updated.
 
 ```js
 cursor.on('update', function(e) {
+  var eventData = e.data;
   console.log('Current data:', eventData.currentData);
   console.log('Previous data:', eventData.previousData);
 });


### PR DESCRIPTION
One of the examples had a typo where there's a missing assignment of `var eventData = e.data;`