### PR TITLE
Supporting TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ It aims at providing a centralized model holding an application's state and can 
     * [Options](#options)
     * [History](#history)
     * [Common pitfalls](#common-pitfalls)
+  * [TypeScript](#typescript)
 * [Philosophy](#philosophy)
 * [Migration](#migration)
 * [Contribution](#contribution)
@@ -1035,6 +1036,54 @@ watcher.release();
 ```
 
 Note also that releasing a tree will consequently and automatically release every of its cursors and computed data nodes.
+
+### TypeScript
+
+**Usage**
+
+1. Checking the `tsconfig.json` of your TypeScript project, and make sure the `compilerOptions` is using `node` module resolution.
+
+```js
+"compilerOptions": {
+  ...
+  "moduleResolution": "node",
+  ...
+}
+```
+
+2. Just importing the exported Classes as below example.
+
+3. Then you can use the imported Classes and APIs in your TypeScript codes.
+
+**Example**
+
+```js
+import { Baobab, Watcher, Cursor } from "baobab";
+
+const yourJSONDataObject = {
+  ...
+}
+
+class AdminDataStore {
+  private storeBackend: Baobab;
+
+  get tree(): Baobab {
+    return this.storeBackend;
+  }
+
+
+  public constructor() {
+    this.storeBackend = new Baobab(yourJSONDataObject, {autoCommit: false, immutable: true});
+  }
+
+  public getData(dataPath: Array<any>): any {
+    return this.storeBackend.select(dataPath).get();
+  }
+
+  ...
+
+}
+```
 
 ## Philosophy
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,378 @@
+/**
+ * TypeScript Definitely Typed File for Baobab
+ */
+
+declare module "baobab" {
+  interface WatchedPaths {
+    [pathX: string]: Array<any>;
+  }
+
+  interface Event {
+    // tslint:disable-next-line: no-reserved-keywords
+    type: string;
+    data: {
+      previousData: any;
+      currentData: any;
+      transaction: any;
+      paths: Array<any>;
+    };
+  }
+
+  type TreeEventType = "update" | "write" | "invalid" | "get" | "select";
+
+  type CursorEventType = "update";
+
+  interface FuncEventCallback {
+    (e: Event): void;
+  }
+
+  interface WatcherCursors {
+    [pathX: string]: Array<Cursor>;
+  }
+
+  type ValidationBehavior = 'rollback' | 'notify';
+
+  /**
+   * Baobab defaults
+   */
+  interface Options {
+    // Should the tree handle its transactions on its own?
+    autoCommit?: boolean;
+
+    // Should the transactions be handled asynchronously?
+    asynchronous?: boolean;
+
+    // Should the tree's data be immutable?
+    immutable?: boolean;
+
+    // Should the monkeys be lazy?
+    lazyMonkeys?: boolean;
+
+    // Should the tree be persistent?
+    persistent?: boolean;
+
+    // Should the tree's update be pure?
+    pure?: boolean;
+
+    // Validation specifications
+    validate?: any;
+
+    // Validation behavior 'rollback' or 'notify'
+    validationBehavior?: ValidationBehavior;
+  }
+
+  /**
+   * Baobab class
+   *
+   * @constructor
+   * @param {object|array} [initialData={}]    - Initial data passed to the tree.
+   * @param {object}       [opts]              - Optional options.
+   * @param {boolean}      [opts.autoCommit]   - Should the tree auto-commit?
+   * @param {boolean}      [opts.asynchronous] - Should the tree's transactions
+   *                                             handled asynchronously?
+   * @param {boolean}      [opts.immutable]    - Should the tree be immutable?
+   * @param {boolean}      [opts.persistent]   - Should the tree be persistent?
+   * @param {boolean}      [opts.pure]         - Should the tree be pure?
+   * @param {function}     [opts.validate]     - Validation function.
+   * @param {string}       [opts.validationBehaviour] - "rollback" or "notify".
+   */
+  class Baobab {
+    constructor(initialData: {}, opts: Options);
+
+    /**
+     * Method used to select data within the tree by creating a cursor. Cursors
+     * are kept as singletons by the tree for performance and hygiene reasons.
+     *
+     * Arity (1):
+     * @param {path}    path - Path to select in the tree.
+     *
+     * Arity (*):
+     * @param {...step} path - Path to select in the tree.
+     *
+     * @return {Cursor}      - The resultant cursor.
+     */
+    public select(...path: Array<any>): Cursor;
+
+    /**
+     * Method used to get data from the tree. Will fire a `get` event from the
+     * tree so that the user may sometimes react upon it to fetch data, for
+     * instance.
+     *
+     * Arity (1):
+     * @param  {path}   path           - Path to get in the tree.
+     *
+     * Arity (2):
+     * @param  {..step} path           - Path to get in the tree.
+     *
+     * @return {mixed}                 - Data at path.
+     */
+    // tslint:disable: no-reserved-keywords
+    public get(): any;
+    public get(...path: Array<any>): any;
+
+    /**
+     * Method used to set data to the tree.
+     *
+     * Arity (1):
+     * @param  {mixed} value - New value to set at cursor's path.
+     *
+     * Arity (2):
+     * @param  {path}  path  - Subpath to update starting from cursor's.
+     * @param  {mixed} value - New value to set.
+     *
+     * @return {mixed}       - Data at path.
+     */
+    public set(newValue: any): any;
+    public set(path: Array<any>, newValue: any): any;
+
+    /**
+     * Method committing the updates of the tree and firing the tree's events.
+     *
+     * @return {Baobab} - The tree instance for chaining purposes.
+     */
+    public commit(): Baobab;
+
+    public on(eventType: TreeEventType | Array<TreeEventType>, cb: FuncEventCallback): void;
+    public off(eventType: TreeEventType | Array<TreeEventType>, cb: FuncEventCallback): void;
+
+    /**
+     * Method used to watch a collection of paths within the tree. Very useful
+     * to bind UI components and such to the tree.
+     *
+     * @param  {object} mapping - Mapping of paths to listen.
+     * @return {Cursor}         - The created watcher.
+     */
+    public watch(paths: WatchedPaths): Watcher;
+
+    /**
+     * Method releasing the tree and its attached data from memory.
+     */
+    public release(): void;
+
+    /**
+     * Overriding the `toJSON` method for convenient use with JSON.stringify.
+     *
+     * @return {mixed} - Data at cursor.
+     */
+    public toJSON(): any;
+
+    /**
+     * Method used to return raw data from the tree, by carefully avoiding
+     * computed one.
+     *
+     * @todo: should be more performant as the cloning should happen as well as
+     * when dropping computed data.
+     *
+     * Arity (1):
+     * @param  {path}   path           - Path to serialize in the tree.
+     *
+     * Arity (2):
+     * @param  {..step} path           - Path to serialize in the tree.
+     *
+     * @return {mixed}                 - The retrieved raw data.
+     */
+    public serialize(...path: Array<any>): any;
+
+    /**
+     * Overriding the `toString` method for debugging purposes.
+     *
+     * @return {string} - The baobab's identity.
+     */
+    public toString(): string;
+  }
+
+  /**
+   * Cursor class
+   *
+   * @constructor
+   * @param {Baobab} tree   - The cursor's root.
+   * @param {array}  path   - The cursor's path in the tree.
+   * @param {string} hash   - The path's hash computed ahead by the tree.
+   */
+  class Cursor {
+    constructor(tree: Baobab, path: Array<any>, hash: string);
+
+    /**
+     * Predicates
+     * -----------
+     */
+
+    /**
+     * Method returning whether the cursor is at root level.
+     *
+     * @return {boolean} - Is the cursor the root?
+     */
+    public isRoot(): boolean;
+
+    /**
+     * Method returning whether the cursor is at leaf level.
+     *
+     * @return {boolean} - Is the cursor a leaf?
+     */
+    public isLeaf(): boolean;
+
+    /**
+     * Method returning whether the cursor is at branch level.
+     *
+     * @return {boolean} - Is the cursor a branch?
+     */
+    public isBranch(): boolean;
+
+    /**
+     * Method returning the root cursor.
+     *
+     * @return {Baobab} - The root cursor.
+     */
+    public root(): Baobab;
+
+    /**
+     * Method used to get data from the cursor. Will fire a `get` event from the
+     * tree so that the user may sometimes react upon it to fetch data, for
+     * instance.
+     *
+     * Arity (1):
+     * @param  {path}   path           - Path to get in the tree.
+     *
+     * Arity (2):
+     * @param  {..step} path           - Path to get in the tree.
+     *
+     * @return {mixed}                 - Data at path.
+     */
+    // tslint:disable: no-reserved-keywords
+    public get(): any;
+    public get(...path: Array<any>): any;
+
+    /**
+     * Method used to set data to the cursor.
+     *
+     * Arity (1):
+     * @param  {mixed} value - New value to set at cursor's path.
+     *
+     * Arity (2):
+     * @param  {path}  path  - Subpath to update starting from cursor's.
+     * @param  {mixed} value - New value to set.
+     *
+     * @return {mixed}       - Data at path.
+     */
+    public set(newValue: any): any;
+    public set(path: Array<any>, newValue: any): any;
+
+    /**
+     * Method selecting a subpath as a new cursor.
+     *
+     * Arity (1):
+     * @param  {path} path    - The path to select.
+     *
+     * Arity (*):
+     * @param  {...step} path - The path to select.
+     *
+     * @return {Cursor}       - The created cursor.
+     */
+    public select(...path: Array<any>): Cursor;
+
+    public clone(...args: Array<any>): any;
+    public deepClone(...args: Array<any>): any;
+
+    /**
+     * Method used to return raw data from the cursor, by carefully avoiding
+     * computed one.
+     *
+     * @todo: should be more performant as the cloning should happen as well as
+     * when dropping computed data.
+     *
+     * Arity (1):
+     * @param  {path}   path           - Path to serialize in the tree.
+     *
+     * Arity (2):
+     * @param  {..step} path           - Path to serialize in the tree.
+     *
+     * @return {mixed}                 - The retrieved raw data.
+     */
+    public serialize(...path: Array<any>): any;
+
+    /**
+     * Methods releasing the cursor from memory.
+     */
+    public release(): void;
+
+    /**
+     * Overriding the `toJSON` method for convenient use with JSON.stringify.
+     *
+     * @return {mixed} - Data at cursor.
+     */
+    public toJSON(): any;
+
+    /**
+     * Overriding the `toString` method for debugging purposes.
+     *
+     * @return {string} - The cursor's identity.
+     */
+    public toString(): string;
+
+    public on(eventType: CursorEventType, cb: FuncEventCallback): void;
+    public off(eventType: CursorEventType, cb: FuncEventCallback): void;
+
+    /**
+     * Method returning the parent node of the cursor or else `null` if the
+     * cursor is already at root level.
+     *
+     * @return {Baobab} - The parent cursor.
+     */
+    public up(): Cursor;
+    public push(newItem: any): Array<any>;
+    /**
+     * Method like Array.splice().
+     *
+     * @param {p} - A array whose elements are start, deleteCount[, item1[, item2[, ...]]]
+     * @return {Array<any>} - The resulted array.
+     */
+    public splice(p: Array<any>): Array<any>;
+    //public map(cb: (itemCursor: Cursor, itemIndex: number) => any): Array<any>;
+  }
+
+  /**
+   * Watcher class.
+   *
+   * @constructor
+   * @param {Baobab} tree     - The watched tree.
+   * @param {object} mapping  - A mapping of the paths to watch in the tree.
+   */
+  class Watcher {
+    constructor(tree: Baobab, watchedPaths: WatchedPaths);
+
+    // tslint:disable: no-reserved-keywords
+    public get(): any;
+
+    public release(): void;
+
+    public on(eventType: CursorEventType, cb: FuncEventCallback): void;
+    public off(eventType: CursorEventType, cb: FuncEventCallback): void;
+
+    /**
+     * Method used to get the current watched paths.
+     *
+     * @return {array} - The array of watched paths.
+     */
+    public getWatchedPaths(): Array<any>;
+
+    /**
+     * Method used to return a map of the watcher's cursors.
+     *
+     * @return {object} - TMap of relevant cursors.
+     */
+    public getCursors(): WatcherCursors;
+
+    /**
+     * Methods releasing the watcher from memory.
+     */
+    public release(): void;
+
+    /**
+     * Method used to refresh the watcher's mapping.
+     *
+     * @param  {object}  mapping  - The new mapping to apply.
+     * @return {Watcher}          - Itself for chaining purposes.
+     */
+    public refresh(mapping: WatchedPaths): Watcher;
+  }
+}

--- a/index.js
+++ b/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = require('./dist/baobab').default;
+
+module.exports.Baobab = require('./dist/baobab').default;
+module.exports.Cursor = require('./dist/cursor').default;
+module.exports.Watcher = require('./dist/watcher').default;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "baobab",
   "version": "2.3.4",
   "description": "JavaScript persistent data tree with cursors.",
-  "main": "./dist/baobab.js",
+  "main": "./index.js",
   "dependencies": {
     "emmett": "^3.1.1"
   },
@@ -10,7 +10,9 @@
     "@yomguithereal/eslint-config": "^1.1.1",
     "add-banner": "^0.1.0",
     "async": "^1.2.1",
-    "babel": "^5.6.14",
+    "babel-cli": "^6.6.4",
+    "babel-core": "^6.6.4",
+    "babel-preset-es2015": "^6.6.0",
     "babelify": "^6.1.2",
     "benchmark": "^1.0.0",
     "browserify": "^12.0.1",
@@ -24,7 +26,7 @@
     "benchmark": "babel-node benchmark.js",
     "build": "mkdirp build && browserify ./src/baobab.js -t [babelify --loose all] -s Baobab -o ./build/baobab.js && uglifyjs ./build/baobab.js -c -m -o ./build/baobab.min.js && node ./scripts/banner.js",
     "check": "npm test && npm run lint && npm run build",
-    "dist": "babel ./src --out-dir dist",
+    "dist": "babel --presets es2015 ./src --out-dir dist",
     "lint": "eslint -c eslint.config.js ./src ./test",
     "prepublish": "npm run dist",
     "test": "mocha -R spec --compilers js:babel/register ./test/endpoint.js"

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -44,7 +44,7 @@ export default class Watcher extends Emitter {
       const watchedPaths = this.getWatchedPaths();
 
       if (solveUpdate(e.data.paths, watchedPaths))
-        return this.emit('update');
+        return this.emit('update', e);
     };
 
     this.tree.on('update', this.handler);


### PR DESCRIPTION
In order to support TypeScript, I changed below. Please review.
1. Upgraded babel from 5.6.14 to the newest 6.6.4, so that the generated ES2015 codes by babel can compatibly work with codes generated by TypeScript compiler and webpack. 
2. Added the TypeScript Definitely Typed File `index.d.ts`.
3. Added `index.js` for working in with `index.d.ts`
4. Modified `package.json` correspondingly.

BTW, I fixed a bug in `watcher.js` which emitted a event without carrying the event object.
