### PR TITLE
Add support for non-enumerable properties

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -215,7 +215,7 @@ function cloner(deep, item) {
       if (type.lazyGetter(item, k)) {
         Object.defineProperty(o, k, {
           get: Object.getOwnPropertyDescriptor(item, k).get,
-          enumerable: Object.getOwnPropertyDescriptor(item, k).enumerable,
+          enumerable: true,
           configurable: true
         });
       }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -206,19 +206,26 @@ function cloner(deep, item) {
   if (type.object(item)) {
     const o = {};
 
-    let k;
+    let i, l, k;
 
     // NOTE: could be possible to erase computed properties through `null`.
-    for (k in item) {
+    const props = Object.getOwnPropertyNames(item);
+    for (i = 0, l = props.length; i < l; i++) {
+      k = props[i];
       if (type.lazyGetter(item, k)) {
         Object.defineProperty(o, k, {
           get: Object.getOwnPropertyDescriptor(item, k).get,
-          enumerable: true,
+          enumerable: Object.getOwnPropertyDescriptor(item, k).enumerable,
           configurable: true
         });
       }
-      else if (hasOwnProp.call(item, k)) {
-        o[k] = deep ? cloner(true, item[k]) : item[k];
+      else {
+        Object.defineProperty(o, k, {
+          value: deep ? cloner(true, item[k]) : item[k],
+          enumerable: Object.getOwnPropertyDescriptor(item, k).enumerable,
+          writable: true,
+          configurable: true
+        });
       }
     }
     return o;

--- a/test/suites/cursor.js
+++ b/test/suites/cursor.js
@@ -322,6 +322,45 @@ describe('Cursor API', function() {
         }, /solve/);
       });
 
+      it('should support setting non-enumerable properties', function() {
+        const tree = new Baobab(Object.create({}, {
+              id: {value: 2, writable: true, enumerable: true},
+              hello: {value: 'world', writable: true, enumerable: false}
+            })),
+            cursor = tree.select('hello');
+
+        cursor.set('universe');
+        assert.equal(cursor.get(), 'universe');
+        assert.equal(Object.getOwnPropertyDescriptor(tree.get(), 'id').enumerable, true);
+        assert.equal(Object.getOwnPropertyDescriptor(tree.get(), 'hello').enumerable, false);
+      });
+
+      it('should support setting deep non-enumerable properties', function() {
+        const tree = new Baobab(Object.create({}, {
+            id: {
+              value: 2,
+              writable: true,
+              enumerable: true
+            },
+            one: {
+              value: Object.create({}, {two: {
+                value: 'three',
+                writable: true,
+                enumerable: false
+              }}),
+              writable: true,
+              enumerable: false,
+            }
+          })),
+          cursor = tree.select(['one', 'two']);
+
+        cursor.set('four');
+        assert.equal(tree.get(['one', 'two']), 'four');
+        assert.equal(Object.getOwnPropertyDescriptor(tree.get(), 'id').enumerable, true);
+        assert.equal(Object.getOwnPropertyDescriptor(tree.get(), 'one').enumerable, false);
+        assert.equal(Object.getOwnPropertyDescriptor(tree.get('one'), 'two').enumerable, false);
+      });
+
       it('should be possible to shallow merge two objects.', function(done) {
         const tree = new Baobab({o: {hello: 'world'}, string: 'test'});
 


### PR DESCRIPTION
Currently the object cloner does not support  cloning non-enumerable properties. This has prevented me from using Baobab on tree structures which include non-enumerable properties.

e.g. The AST provided by [recast](https://github.com/benjamn/recast) has a non-enumerable `original` member for each node. Manipulating the tree with Baobab results in this property being lost on all cloned nodes.

This PR opts to use [`Object.getOwnPropertyNames`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames) instead of the `for in` loop, allowing non-enumerable properties to be cloned with their descriptors intact. This also mitigates the need for the use of `hasOwnProp`.