### PR TITLE
Fix history .undo() - unnecessary condition

### DIFF
--- a/src/cursor.js
+++ b/src/cursor.js
@@ -625,9 +625,6 @@ export default class Cursor extends Emitter {
 
     const record = this.archive.back(steps);
 
-    if (!record)
-      throw Error('Baobab.Cursor.undo: cannot find a relevant record.');
-
     this.state.undoing = true;
     this.set(record);
 


### PR DESCRIPTION
Hi, I think that this throw Error is unnecessary, becouse if in the tree is stored value that returns false in the if condition you can't use methods .undo (), because it always returns throw error.
This blocking me, because I have a lot of value in the tree like null, false and i get error when i try undo to this value.