### PR TITLE
Fixed formatting in helpers-testsuite

### DIFF
--- a/test/suites/helpers.js
+++ b/test/suites/helpers.js
@@ -239,12 +239,12 @@ describe('Helpers', function() {
         const array = [0, 1, 2, 3, 4];
 
         assert.throws(function () {
-			splice(array, 2, "a");
-		}, Error);
+          splice(array, 2, "a");
+        }, Error);
 
         assert.throws(function () {
-			splice(array, 2, {});
-		}, Error);
+            splice(array, 2, {});
+        }, Error);
       });
     });
   });


### PR DESCRIPTION
There was a small formatting error in the last commit of #473.

This commit and pull request only fixes the formatting and leaves any functions of the code untouched.

As such, bumping the version and publishing on npm is not necessary for this fix.

(My bad for missing it last time, my IDE did some code completion with wrong formatting settings when writing the tests).

