### PR TITLE
Remove the correct monkey listener when re-setting a monkey

### DIFF
--- a/src/monkey.js
+++ b/src/monkey.js
@@ -263,7 +263,7 @@ export class Monkey {
 
     // Unbinding events
     this.tree.off('write', this.writeListener);
-    this.tree.off('_monkey', this.monkeyListener);
+    this.tree.off('_monkey', this.recursiveListener);
     this.state.killed = true;
 
     // Deleting properties

--- a/test/suites/monkey.js
+++ b/test/suites/monkey.js
@@ -530,7 +530,7 @@ describe('Monkeys', function() {
       assert.strictEqual(tree.get('data', 'selected'), 'purple');
     });
 
-	it('with mutable, non-persistent, impure tree.', function() {
+    it('with mutable, non-persistent, impure tree.', function() {
       const tree = new Baobab(
         {
           data: {
@@ -548,6 +548,29 @@ describe('Monkeys', function() {
       assert.strictEqual(tree.get('data', 'selected'), 'purple');
     });
 
+    it('releases all listeners from the existing monkey', function() {
+      const state = {
+        data: {
+          colors: ['yellow', 'blue'],
+          selected: monkey(['data', 'colors'], c => c[0])
+        }
+      };
+      const tree = new Baobab(state);
+
+      assert.strictEqual(tree.get('data', 'selected'), 'yellow');
+      assert.strictEqual(tree.listeners('write').length, 1);
+      assert.strictEqual(tree.listeners('_monkey').length, 1);
+
+      tree.set(['data', 'selected'], monkey(['data', 'colors'], c => c[1]));
+      assert.strictEqual(tree.get('data', 'selected'), 'blue');
+      assert.strictEqual(tree.listeners('write').length, 1);
+      assert.strictEqual(tree.listeners('_monkey').length, 1);
+
+      tree.set(state);
+      assert.strictEqual(tree.get('data', 'selected'), 'yellow');
+      assert.strictEqual(tree.listeners('write').length, 1);
+      assert.strictEqual(tree.listeners('_monkey').length, 1);
+    });
   });
 
   it('should be possible to drop monkeys somehow.', function() {


### PR DESCRIPTION
Closes #478 by fixing typo that was preventing the private _monkey listener from unbinding.  Wasn't sure if there is a better way to check the unbinding of the listener, but test did repro the issue.