### PR TITLE
Use global isNaN and parseInt for IE/Safari support

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -570,11 +570,11 @@ export function solveUpdate(affectedPaths, comparedPaths) {
  * @return {array}                 - The spliced array.
  */
 export function splice(array, startIndex, nb, ...elements) {
-  if (nb === undefined)
+  if (nb === undefined && arguments.length === 2)
     nb = array.length - startIndex;
-  else if (nb === null)
+  else if (nb === null || nb === undefined)
     nb = 0;
-  else if (Number.isNaN(Number.parseInt(nb, 10)))
+  else if (isNaN(+nb))
     throw new Error(`argument nb ${nb} can not be parsed into a number!`);
   nb = Math.max(0, nb);
 

--- a/src/type.js
+++ b/src/type.js
@@ -114,7 +114,7 @@ type.primitive = function(target) {
 type.splicer = function(target) {
   if (!type.array(target) || target.length < 1)
     return false;
-  if (target.length > 1 && Number.isNaN(Number.parseInt(target[1], 10)))
+  if (target.length > 1 && isNaN(+target[1]))
     return false;
 
   return anyOf(target[0], ['number', 'function', 'object']);

--- a/test/suites/helpers.js
+++ b/test/suites/helpers.js
@@ -225,14 +225,40 @@ describe('Helpers', function() {
     });
 
     describe('Issue #472 - tree/cursor.splice does not conform with the specification as of ES6 (ECMAScript 2015)', function () {
-      it('should be possible to splice an array when omitting the nb (deleteCount) argument or passing null', function () {
+      it('should be possible to splice an array when omitting the nb (deleteCount) argument', function () {
         const array = [0, 1, 2, 3, 4];
 
         assert.deepEqual(splice(array, 2), [0, 1]);
 
         assert.deepEqual(splice(array, -2), [0, 1, 2]);
+      });
 
-        assert.deepEqual(splice(array, 2, null), [0, 1, 2, 3, 4]);
+      it('should ignore the nb (deleteCount) argument when passing null, undefined, empty string, or false', function () {
+        const array = [0, 1, 2, 3, 4];
+
+        assert.deepEqual(splice(array, 2, null), [0, 1, 2, 3, 4], 'null for nb');
+        assert.deepEqual(splice(array, 2, null, 5), [0, 1, 5, 2, 3, 4], 'null for nb with new item');
+
+        assert.deepEqual(splice(array, 2, undefined), [0, 1, 2, 3, 4], 'undefined for nb');
+        assert.deepEqual(splice(array, 2, undefined, 5), [0, 1, 5, 2, 3, 4], 'undefined for nb with new item');
+
+        assert.deepEqual(splice(array, 2, ''), [0, 1, 2, 3, 4], '"" for nb');
+        assert.deepEqual(splice(array, 2, '', 5), [0, 1, 5, 2, 3, 4], '"" for nb with new item');
+
+        assert.deepEqual(splice(array, 2, false), [0, 1, 2, 3, 4], 'false for nb');
+        assert.deepEqual(splice(array, 2, false, 5), [0, 1, 5, 2, 3, 4], 'false for nb with new item');
+      });
+
+      it('should allow for nb (deleteCount) argument to be true, a coereced string, a decimal, or Infinity', function () {
+        const array = [0, 1, 2, 3, 4];
+
+        assert.deepEqual(splice(array, 2, true), [0, 1, 3, 4], 'true for nb');
+
+        assert.deepEqual(splice(array, 2, '1'), [0, 1, 3, 4], '"1" for nb');
+
+        assert.deepEqual(splice(array, 2, 1.2), [0, 1, 3, 4], '1.2 for nb');
+
+        assert.deepEqual(splice(array, 2, Infinity), [0, 1], 'Infinity for nb');
       });
 
       it('should throw an error when supplying an argument for nb (deleteCount) which is not parseable as number', function () {


### PR DESCRIPTION
Unfortunately neither Safari or IE support the versions of isNaN and
parseInt that are on the Number object.