### PR TITLE
Increase performance deep clone of Array

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -176,13 +176,10 @@ function cloner(deep, item) {
   // Array
   if (type.array(item)) {
     if (deep) {
-      const a = [];
+      const a = new Array(item.length);
 
-      let i,
-          l;
-
-      for (i = 0, l = item.length; i < l; i++)
-        a.push(cloner(true, item[i]));
+      for (let i = 0, l = item.length; i < l; i++)
+        a[i] = cloner(true, item[i]);
       return a;
     }
 


### PR DESCRIPTION
map function calculate a length of Array on start of clone and doesn't change later

Chrome 63 beta
![image](https://user-images.githubusercontent.com/4757846/32592634-bd397fd2-c535-11e7-884c-52fc0153562e.png)

IE11
![image](https://user-images.githubusercontent.com/4757846/32592657-d33259f8-c535-11e7-9961-39d0ffb2424c.png)

From https://jsperf.com/map-vs-for-loop-performance/6